### PR TITLE
Issue 8 & 25: Add Turn Counter, Reset Game Button, and Related Tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ coverage/
 *.njsproj
 *.sln
 *.sw?
+
+.codegpt

--- a/jest.config.js
+++ b/jest.config.js
@@ -16,6 +16,7 @@ export default {
     '^@hooks(.*)$': '<rootDir>/src/hooks$1', // Alias for hooks
     '^@logics(.*)$': '<rootDir>/src/logics$1', // Alias for logic
     '^@app$': '<rootDir>/src/App.jsx', // Alias for the main App component
+    '^@constants(.*)$': '<rootDir>/src/constants$1', // Alias for constants
   },
 
   transformIgnorePatterns: [

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -7,7 +7,8 @@
       "@hooks/*": ["src/hooks/*"],
       "@logics/*": ["src/logics/*"],
       "@supports/*": ["src/tests/supports/*"],
-      "@utils/*": ["src/utils/*"]
+      "@utils/*": ["src/utils/*"],
+      "@constants/*": ["src/constants/*"],
     }
   },
   "include": ["src", "tests"]

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,10 @@
 import React from 'react';
-import { GameBoard, GameMessages } from '@components';
+import {
+  GameBoard,
+  GameMessages,
+  MoveCounter,
+  RestartButton,
+} from '@components';
 import { Providers } from '@contexts';
 
 function App() {
@@ -10,6 +15,8 @@ function App() {
           <h1 className="app-title">Tower of Hanoi</h1>
           <main>
             <GameMessages />
+            <MoveCounter />
+            <RestartButton />
             <GameBoard />
           </main>
         </Providers>

--- a/src/components/MoveCounter.jsx
+++ b/src/components/MoveCounter.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { useGame } from '@contexts';
+
+const MoveCounter = () => {
+  const { moveCount, game } = useGame();
+  const minimumMoves = game.calculateMinimumMoves();
+
+  return (
+    <div className="move-counter">
+      <h2 className="move-count" data-testid="move-count">
+        Move Count: {moveCount}
+      </h2>
+      <h2 className="minimum-moves" data-testid="minimum-moves">
+        Minimum Moves: {minimumMoves}
+      </h2>
+    </div>
+  );
+};
+
+export default MoveCounter;

--- a/src/components/RestartButton.jsx
+++ b/src/components/RestartButton.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { useRestartGame } from '@hooks';
+
+const RestartButton = () => {
+  const restartGame = useRestartGame();
+
+  return <button onClick={restartGame}>Restart Game</button>;
+};
+
+export default RestartButton;

--- a/src/components/index.jsx
+++ b/src/components/index.jsx
@@ -5,3 +5,5 @@ export { default as Disk } from './Disk';
 export { default as TowerSpike } from './TowerSpike';
 export { default as Base } from './Base';
 export { default as GameMessages } from './GameMessages';
+export { default as MoveCounter } from './MoveCounter';
+export { default as RestartButton } from './RestartButton';

--- a/src/constants/gameConstants.js
+++ b/src/constants/gameConstants.js
@@ -1,0 +1,3 @@
+export const VICTORY_MESSAGE = 'Congratulations! You have won the game!';
+export const INVALID_MOVE_MESSAGE = 'Invalid move!';
+export const NUMBER_OF_TOWERS = 3;

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,0 +1,1 @@
+export * from './gameConstants';

--- a/src/contexts/index.js
+++ b/src/contexts/index.js
@@ -1,9 +1,4 @@
-// Export GameContext utilities
 export { default as GameProvider } from './GameContext';
 export { useGame } from './GameContext';
-
-// Export DndContext utilities
 export { default as DndProviderContext } from './DndContext';
-
-// Export "Providers" for wrapping main app
 export { default as Providers } from './Providers';

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,5 +1,4 @@
-// Export everything from useClickMovement
 export { default as useClickMovement } from './useClickMovement';
-
-// Export named hooks from useDragAndDrop
 export { useDiskDrag, useTowerDrop } from './useDragAndDrop';
+export { useRestartGame } from './useRestartGame';
+export { useHandleMoveDisk } from './useHandleMoveDisk';

--- a/src/hooks/useDragAndDrop.jsx
+++ b/src/hooks/useDragAndDrop.jsx
@@ -32,7 +32,9 @@ export const useDiskDrag = (size, towerIndex, isTopDisk) => {
 export const useTowerDrop = (towerIndex, onDiskDrop) => {
   const [{ isOver }, drop] = useDrop(() => ({
     accept: 'disk',
-    drop: (item) => onDiskDrop(item.sourceTowerIndex, towerIndex),
+    drop: (item) => {
+      onDiskDrop(item.sourceTowerIndex, towerIndex);
+    },
     collect: (monitor) => ({
       isOver: monitor.isOver(),
     }),

--- a/src/hooks/useHandleMoveDisk.js
+++ b/src/hooks/useHandleMoveDisk.js
@@ -1,0 +1,32 @@
+import { useCallback, useRef } from 'react';
+import { incrementMoveCount } from '@utils';
+import { VICTORY_MESSAGE, INVALID_MOVE_MESSAGE } from '@constants';
+
+export const useHandleMoveDisk = ({
+  game,
+  setTowers,
+  setMoveCount,
+  setVictoryMessage,
+  setInvalidMoveMessage,
+}) => {
+  const gameRef = useRef(game);
+  gameRef.current = game;
+
+  const handleMoveDisk = useCallback(
+    (fromTower, toTower) => {
+      try {
+        gameRef.current.moveDisk(fromTower, toTower);
+        setTowers([...gameRef.current.towers]); // Update the towers state
+        incrementMoveCount(setMoveCount); // Increment move count
+        if (gameRef.current.isGameWon()) {
+          setVictoryMessage(VICTORY_MESSAGE);
+        }
+      } catch {
+        setInvalidMoveMessage(INVALID_MOVE_MESSAGE);
+      }
+    },
+    [game, setTowers, setMoveCount, setVictoryMessage, setInvalidMoveMessage], // Dependencies
+  );
+
+  return handleMoveDisk;
+};

--- a/src/hooks/useRestartGame.js
+++ b/src/hooks/useRestartGame.js
@@ -1,0 +1,14 @@
+import { useGame } from '@contexts';
+
+export const useRestartGame = () => {
+  const { resetGame } = useGame();
+
+  const restartGame = () => {
+    const newNumDisks = prompt('Enter the number of disks for the new game:');
+    if (newNumDisks && !isNaN(newNumDisks)) {
+      resetGame(Number(newNumDisks));
+    }
+  };
+
+  return restartGame;
+};

--- a/src/logics/gameLogic.js
+++ b/src/logics/gameLogic.js
@@ -31,4 +31,8 @@ export default class GameLogic {
       this.towers[2].length === this.numDisks
     );
   }
+
+  calculateMinimumMoves() {
+    return Math.pow(2, this.numDisks) - 1;
+  }
 }

--- a/src/tests/components/App.test.jsx
+++ b/src/tests/components/App.test.jsx
@@ -20,6 +20,18 @@ jest.mock('@components/GameMessages', () => ({
   default: jest.fn(() => <div data-testid="game-messages">Game Messages</div>),
 }));
 
+jest.mock('@components/MoveCounter', () => ({
+  __esModule: true,
+  default: jest.fn(() => <div data-testid="move-counter">Move Counter</div>),
+}));
+
+jest.mock('@components/RestartButton', () => ({
+  __esModule: true,
+  default: jest.fn(() => (
+    <div data-testid="restart-button">Restart Button</div>
+  )),
+}));
+
 jest.mock('@components/GameBoard', () => ({
   __esModule: true,
   default: jest.fn(() => <div data-testid="game-board">Game Board</div>),
@@ -48,15 +60,27 @@ describe('App', () => {
     expect(screen.getByTestId('game-messages')).toBeInTheDocument();
   });
 
+  it('renders MoveCounter', () => {
+    render(<App />);
+    expect(screen.getByTestId('move-counter')).toBeInTheDocument();
+  });
+
+  it('renders RestartButton', () => {
+    render(<App />);
+    expect(screen.getByTestId('restart-button')).toBeInTheDocument();
+  });
+
   it('renders GameBoard', () => {
     render(<App />);
     expect(screen.getByTestId('game-board')).toBeInTheDocument();
   });
 
-  it('wraps GameMessages and GameBoard inside Providers', () => {
+  it('wraps all components inside Providers', () => {
     render(<App />);
     const appContainer = screen.getByRole('main');
     expect(appContainer).toContainElement(screen.getByTestId('game-messages'));
+    expect(appContainer).toContainElement(screen.getByTestId('move-counter'));
+    expect(appContainer).toContainElement(screen.getByTestId('restart-button'));
     expect(appContainer).toContainElement(screen.getByTestId('game-board'));
   });
 });

--- a/src/tests/components/MoveCounter.test.jsx
+++ b/src/tests/components/MoveCounter.test.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { useGame } from '@contexts';
+import MoveCounter from '@components/MoveCounter';
+
+// Mock gameContext
+jest.mock('@contexts', () => ({
+  useGame: jest.fn(),
+}));
+
+describe('MoveCounter Component', () => {
+  beforeEach(() => {
+    useGame.mockReturnValue({
+      moveCount: 3,
+      game: {
+        calculateMinimumMoves: jest.fn(() => 7),
+      },
+    });
+  });
+
+  it('renders correctly with provided props', () => {
+    render(<MoveCounter />);
+
+    // Check that the move count is displayed correctly
+    expect(screen.getByText('Move Count: 3')).toBeInTheDocument();
+
+    // Check that the minimum moves is displayed correctly
+    expect(screen.getByText('Minimum Moves: 7')).toBeInTheDocument();
+  });
+});

--- a/src/tests/components/RestartButton.test.jsx
+++ b/src/tests/components/RestartButton.test.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { RestartButton } from '@components';
+import { useRestartGame } from '@hooks';
+
+jest.mock('@hooks', () => ({
+  useRestartGame: jest.fn(),
+}));
+
+describe('RestartButton Component', () => {
+  it('renders the restart button', () => {
+    useRestartGame.mockReturnValue(jest.fn());
+    render(<RestartButton />);
+
+    expect(screen.getByText('Restart Game')).toBeInTheDocument();
+  });
+
+  it('calls restartGame when clicked', () => {
+    const mockRestartGame = jest.fn();
+    useRestartGame.mockReturnValue(mockRestartGame);
+
+    render(<RestartButton />);
+    fireEvent.click(screen.getByText('Restart Game'));
+
+    expect(mockRestartGame).toHaveBeenCalled();
+  });
+});

--- a/src/tests/constants/gameConstants.test.js
+++ b/src/tests/constants/gameConstants.test.js
@@ -1,0 +1,15 @@
+import * as gameConstants from '@constants';
+
+describe('gameConstants', () => {
+  it('should define VICTORY_MESSAGE, INVALID_MOVE_MESSAGE, and NUMBER_OF_TOWERS with correct types', () => {
+    expect(gameConstants.VICTORY_MESSAGE).toBeDefined();
+    expect(typeof gameConstants.VICTORY_MESSAGE).toBe('string');
+
+    expect(gameConstants.INVALID_MOVE_MESSAGE).toBeDefined();
+    expect(typeof gameConstants.INVALID_MOVE_MESSAGE).toBe('string');
+
+    expect(gameConstants.NUMBER_OF_TOWERS).toBeDefined();
+    expect(typeof gameConstants.NUMBER_OF_TOWERS).toBe('number');
+    expect(Number.isInteger(gameConstants.NUMBER_OF_TOWERS)).toBe(true);
+  });
+});

--- a/src/tests/contexts/DndContext.test.jsx
+++ b/src/tests/contexts/DndContext.test.jsx
@@ -13,7 +13,7 @@
 
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import DndProviderContext from '@contexts/DndContext';
+import { DndProviderContext } from '@contexts';
 import { DndProvider } from 'react-dnd';
 
 // Mock DndProvider to verify backend prop

--- a/src/tests/contexts/GameContext.test.jsx
+++ b/src/tests/contexts/GameContext.test.jsx
@@ -1,97 +1,143 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
-import { GameProvider, DndProviderContext } from '@contexts';
+import { render, act } from '@testing-library/react';
+import { GameProvider, useGame } from '@contexts';
 import { GameLogic } from '@logics';
-import { GameBoard, GameMessages } from '@components';
 
 jest.mock('@logics', () => ({
   GameLogic: jest.fn(),
 }));
 
-jest.mock('@utils/gameStateUtils', () => ({
-  clearMessages: jest.fn(),
-  resetSelection: jest.fn(),
-  isTopDisk: jest.fn(),
+jest.mock('@hooks', () => ({
+  useHandleMoveDisk: jest.fn(() => jest.fn()), // Mock the hook as a no-op function
 }));
 
-describe('handleMoveDisk behavior', () => {
-  let mockMoveDisk, mockIsGameWon;
-  const towers = [[3, 2, 1], [], []];
-
-  const renderWithProvider = ({ ui = null, numDisks = 2 } = {}) => {
-    return render(
-      <GameProvider numDisks={numDisks}>
-        <DndProviderContext>
-          <div>
-            <GameMessages />
-            {ui || <GameBoard />}
-          </div>
-        </DndProviderContext>
-      </GameProvider>,
-    );
-  };
+describe('GameContext', () => {
+  let mockGameInstance;
 
   beforeEach(() => {
-    mockMoveDisk = jest.fn();
-    mockIsGameWon = jest.fn();
+    // Mock the GameLogic instance
+    mockGameInstance = {
+      towers: [[3, 2, 1], [], []],
+      isGameWon: jest.fn(),
+    };
 
-    GameLogic.mockImplementation(() => ({
-      towers,
-      moveDisk: mockMoveDisk,
-      isGameWon: mockIsGameWon,
-    }));
+    GameLogic.mockImplementation((numDisks) => {
+      return {
+        towers: [
+          Array.from({ length: numDisks }, (_, i) => numDisks - i),
+          [],
+          [],
+        ],
+        isGameWon: jest.fn(),
+      };
+    });
   });
 
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  test('updates towers and does not set messages on a valid move', () => {
-    renderWithProvider();
+  const TestComponent = () => {
+    const {
+      numDisks,
+      towers,
+      resetGame,
+      victoryMessage,
+      invalidMoveMessage,
+      moveCount,
+      selectedDisk,
+      selectedTower,
+    } = useGame();
 
-    mockMoveDisk.mockImplementation(() => {
-      towers[1].push(towers[0].pop());
-    });
+    return (
+      <div>
+        <div data-testid="num-disks">{numDisks}</div>
+        <div data-testid="towers">{JSON.stringify(towers)}</div>
+        <div data-testid="victory-message">{victoryMessage}</div>
+        <div data-testid="invalid-move-message">{invalidMoveMessage}</div>
+        <div data-testid="move-count">{moveCount}</div>
+        <div data-testid="selected-disk">{JSON.stringify(selectedDisk)}</div>
+        <div data-testid="selected-tower">{JSON.stringify(selectedTower)}</div>
+        <button data-testid="reset-button" onClick={() => resetGame(4)}>
+          Reset Game
+        </button>
+      </div>
+    );
+  };
 
-    // Perform a valid move
-    fireEvent.click(screen.getByTestId('tower-0'));
-    fireEvent.click(screen.getByTestId('tower-1'));
+  it('initializes with default values', () => {
+    const { getByTestId } = render(
+      <GameProvider>
+        <TestComponent />
+      </GameProvider>,
+    );
 
-    // Validate towers are updated and no messages are set
-    expect(towers).toEqual([[3, 2], [1], []]);
-    expect(screen.queryByText(/Invalid move!/i)).toBeNull();
-    expect(screen.queryByText(/Congratulations!/i)).toBeNull();
+    expect(getByTestId('num-disks').textContent).toBe('3'); // Default disks
+    expect(getByTestId('towers').textContent).toBe(
+      JSON.stringify([[3, 2, 1], [], []]), // Default towers
+    );
+    expect(getByTestId('victory-message').textContent).toBe(''); // Default empty message
+    expect(getByTestId('invalid-move-message').textContent).toBe(''); // Default empty message
+    expect(getByTestId('move-count').textContent).toBe('0'); // Default move count
   });
 
-  test('sets victory message when game is won', () => {
-    renderWithProvider();
+  it('initializes with a custom number of disks', () => {
+    mockGameInstance.towers = [[5, 4, 3, 2, 1], [], []];
 
-    mockMoveDisk.mockImplementation(() => {
-      towers[1].push(towers[0].pop());
-    });
+    const { getByTestId } = render(
+      <GameProvider initialNumDisks={5}>
+        <TestComponent />
+      </GameProvider>,
+    );
 
-    mockIsGameWon.mockReturnValueOnce(true);
-
-    // Perform the winning move
-    fireEvent.click(screen.getByTestId('tower-0'));
-    fireEvent.click(screen.getByTestId('tower-1'));
-
-    // Validate victory message is set
-    expect(screen.getByText(/Congratulations!/i)).toBeInTheDocument();
+    expect(getByTestId('num-disks').textContent).toBe('5'); // Custom disks
+    expect(getByTestId('towers').textContent).toBe(
+      JSON.stringify([[5, 4, 3, 2, 1], [], []]), // Custom towers
+    );
   });
 
-  test('sets invalid move message on an invalid move', () => {
-    renderWithProvider();
+  it('resets the game with a new number of disks', async () => {
+    const { getByTestId } = render(
+      <GameProvider>
+        <TestComponent />
+      </GameProvider>,
+    );
 
-    mockMoveDisk.mockImplementation(() => {
-      throw new Error('Invalid move!');
+    // Trigger reset
+    await act(async () => {
+      getByTestId('reset-button').click();
     });
 
-    // Perform an invalid move (Error is thrown by mockMoveDisk above)
-    fireEvent.click(screen.getByTestId('tower-0'));
-    fireEvent.click(screen.getByTestId('tower-1'));
+    // Ensure GameLogic was initialized with the new disk count
+    expect(GameLogic).toHaveBeenCalledWith(4);
 
-    // Validate invalid move message is set
-    expect(screen.getByText(/Invalid move!/i)).toBeInTheDocument();
+    // Wait for state updates and validate the towers
+    expect(getByTestId('num-disks').textContent).toBe('4'); // Updated disks
+    expect(getByTestId('towers').textContent).toBe(
+      JSON.stringify([[4, 3, 2, 1], [], []]), // Updated towers
+    );
+
+    // Verify reset state
+    expect(getByTestId('move-count').textContent).toBe('0'); // Reset move count
+    expect(getByTestId('victory-message').textContent).toBe(''); // Reset victory message
+    expect(getByTestId('invalid-move-message').textContent).toBe(''); // Reset invalid move message
+
+    expect(getByTestId('selected-disk').textContent).toBe('null'); // Disk reset
+    expect(getByTestId('selected-tower').textContent).toBe('null'); // Tower reset
+  });
+
+  it('provides all required values and functions', () => {
+    const { getByTestId } = render(
+      <GameProvider>
+        <TestComponent />
+      </GameProvider>,
+    );
+
+    expect(getByTestId('num-disks')).toBeInTheDocument();
+    expect(getByTestId('towers')).toBeInTheDocument();
+    expect(getByTestId('victory-message')).toBeInTheDocument();
+    expect(getByTestId('invalid-move-message')).toBeInTheDocument();
+    expect(getByTestId('move-count')).toBeInTheDocument();
+    expect(getByTestId('reset-button')).toBeInTheDocument();
   });
 });

--- a/src/tests/hooks/useDragAndDrop.test.jsx
+++ b/src/tests/hooks/useDragAndDrop.test.jsx
@@ -21,7 +21,21 @@ jest.mock('@utils', () => ({
 
 describe('useDragAndDrop hooks', () => {
   beforeEach(() => {
+    jest.clearAllMocks(); // Clear mocks before re-mocking
+    const useDragMock = jest.requireMock('react-dnd').useDrag;
+    useDragMock.mockImplementation(() => [{ isDragging: false }, jest.fn()]);
+
+    useGame.mockReturnValue({
+      setSelectedDisk: jest.fn(),
+      setSelectedTower: jest.fn(),
+      setInvalidMoveMessage: jest.fn(),
+      setVictoryMessage: jest.fn(),
+    });
+  });
+
+  afterEach(() => {
     jest.clearAllMocks();
+    jest.resetAllMocks();
   });
 
   describe('useDiskDrag', () => {
@@ -92,6 +106,20 @@ describe('useDragAndDrop hooks', () => {
 
       useDiskDrag(3, 0, true);
     });
+    it('calls collect to monitor isDragging state', () => {
+      const mockMonitor = { isDragging: jest.fn(() => true) };
+
+      const useDragMock = jest.requireMock('react-dnd').useDrag;
+      useDragMock.mockImplementation((config) => {
+        const { collect } = config();
+        expect(collect(mockMonitor)).toEqual({ isDragging: true }); // Verify collect behavior
+        return [{ isDragging: true }, jest.fn()];
+      });
+
+      const { isDragging } = useDiskDrag(3, 0, true);
+
+      expect(isDragging).toBe(true); // Ensure the state matches
+    });
   });
 
   describe('useTowerDrop', () => {
@@ -125,6 +153,21 @@ describe('useDragAndDrop hooks', () => {
 
       expect(getByTestId('over')).toHaveTextContent('Over');
       expect(mockOnDiskDrop).toHaveBeenCalledWith(0, 1);
+    });
+
+    it('calls collect to monitor isOver state', () => {
+      const mockMonitor = { isOver: jest.fn(() => true) };
+
+      const useDropMock = jest.requireMock('react-dnd').useDrop;
+      useDropMock.mockImplementation((config) => {
+        const { collect } = config();
+        expect(collect(mockMonitor)).toEqual({ isOver: true }); // Verify collect behavior
+        return [{ isOver: true }, jest.fn()];
+      });
+
+      const { isOver } = useTowerDrop(1, jest.fn());
+
+      expect(isOver).toBe(true); // Ensure the state matches
     });
   });
 });

--- a/src/tests/hooks/useHandleMoveDisk.test.jsx
+++ b/src/tests/hooks/useHandleMoveDisk.test.jsx
@@ -1,0 +1,139 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { render } from '@testing-library/react';
+import { useHandleMoveDisk } from '@hooks';
+import { incrementMoveCount } from '@utils';
+
+jest.mock('@utils', () => ({
+  incrementMoveCount: jest.fn(),
+}));
+
+// Mock component for testing the hook
+const HookTester = ({
+  game,
+  setTowers,
+  setMoveCount,
+  setVictoryMessage,
+  setInvalidMoveMessage,
+  fromTower,
+  toTower,
+}) => {
+  const handleMoveDisk = useHandleMoveDisk({
+    game,
+    setTowers,
+    setMoveCount,
+    setVictoryMessage,
+    setInvalidMoveMessage,
+  });
+
+  React.useEffect(() => {
+    handleMoveDisk(fromTower, toTower);
+  }, [fromTower, toTower, handleMoveDisk]);
+
+  return <div data-testid="hook-tester">Hook Tester</div>;
+};
+
+describe('useHandleMoveDisk', () => {
+  let mockGame,
+    mockSetTowers,
+    mockSetMoveCount,
+    mockSetVictoryMessage,
+    mockSetInvalidMoveMessage;
+
+  beforeEach(() => {
+    mockGame = {
+      moveDisk: jest.fn(),
+      towers: [[3, 2], [1], []],
+      isGameWon: jest.fn(),
+    };
+    mockSetTowers = jest.fn();
+    mockSetMoveCount = jest.fn();
+    mockSetVictoryMessage = jest.fn();
+    mockSetInvalidMoveMessage = jest.fn();
+
+    incrementMoveCount.mockImplementation((setMoveCount) =>
+      setMoveCount((prev) => prev + 1),
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('handles a valid move by updating towers and incrementing move count', () => {
+    render(
+      <HookTester
+        game={mockGame}
+        setTowers={mockSetTowers}
+        setMoveCount={mockSetMoveCount}
+        setVictoryMessage={mockSetVictoryMessage}
+        setInvalidMoveMessage={mockSetInvalidMoveMessage}
+        fromTower={0}
+        toTower={1}
+      />,
+    );
+
+    // Ensure the correct move was made
+    expect(mockGame.moveDisk).toHaveBeenCalledWith(0, 1);
+
+    // Corrected expectation
+    expect(mockSetTowers).toHaveBeenCalledWith([[3, 2], [1], []]);
+    expect(incrementMoveCount).toHaveBeenCalledWith(mockSetMoveCount);
+    expect(mockSetVictoryMessage).not.toHaveBeenCalled();
+    expect(mockSetInvalidMoveMessage).not.toHaveBeenCalled();
+  });
+
+  it('sets victory message when the game is won', () => {
+    mockGame.isGameWon.mockReturnValueOnce(true);
+
+    render(
+      <HookTester
+        game={mockGame}
+        setTowers={mockSetTowers}
+        setMoveCount={mockSetMoveCount}
+        setVictoryMessage={mockSetVictoryMessage}
+        setInvalidMoveMessage={mockSetInvalidMoveMessage}
+        fromTower={0}
+        toTower={1}
+      />,
+    );
+
+    expect(mockSetVictoryMessage).toHaveBeenCalledWith(
+      'Congratulations! You have won the game!',
+    );
+  });
+
+  it('sets invalid move message on an invalid move', () => {
+    mockGame.moveDisk.mockImplementation(() => {
+      throw new Error('Invalid move!');
+    });
+
+    render(
+      <HookTester
+        game={mockGame}
+        setTowers={mockSetTowers}
+        setMoveCount={mockSetMoveCount}
+        setVictoryMessage={mockSetVictoryMessage}
+        setInvalidMoveMessage={mockSetInvalidMoveMessage}
+        fromTower={0}
+        toTower={1}
+      />,
+    );
+
+    expect(mockSetInvalidMoveMessage).toHaveBeenCalledWith('Invalid move!');
+  });
+});
+
+HookTester.propTypes = {
+  game: PropTypes.shape({
+    moveDisk: PropTypes.func.isRequired,
+    towers: PropTypes.array.isRequired,
+    isGameWon: PropTypes.func.isRequired,
+  }).isRequired,
+  setTowers: PropTypes.func.isRequired,
+  setMoveCount: PropTypes.func.isRequired,
+  setVictoryMessage: PropTypes.func.isRequired,
+  setInvalidMoveMessage: PropTypes.func.isRequired,
+  fromTower: PropTypes.number.isRequired,
+  toTower: PropTypes.number.isRequired,
+};

--- a/src/tests/hooks/useRestartGame.test.jsx
+++ b/src/tests/hooks/useRestartGame.test.jsx
@@ -1,0 +1,35 @@
+import { useGame } from '@contexts';
+import { useRestartGame } from '@hooks';
+
+jest.mock('@contexts', () => ({
+  useGame: jest.fn(),
+}));
+
+describe('useRestartGame', () => {
+  let resetGame;
+
+  beforeEach(() => {
+    resetGame = jest.fn();
+    useGame.mockReturnValue({ resetGame });
+  });
+
+  it('calls resetGame with user input', () => {
+    jest.spyOn(window, 'prompt').mockReturnValue('3'); // Simulate user input
+
+    const restartGame = useRestartGame();
+    restartGame();
+
+    expect(resetGame).toHaveBeenCalledWith(3);
+    window.prompt.mockRestore();
+  });
+
+  it('does not call resetGame if input is invalid', () => {
+    jest.spyOn(window, 'prompt').mockReturnValue('invalid'); // Simulate invalid input
+
+    const restartGame = useRestartGame();
+    restartGame();
+
+    expect(resetGame).not.toHaveBeenCalled();
+    window.prompt.mockRestore();
+  });
+});

--- a/src/tests/logics/gameLogic.test.jsx
+++ b/src/tests/logics/gameLogic.test.jsx
@@ -86,4 +86,16 @@ describe('GameLogic', () => {
       expect(game.isGameWon()).toBe(true);
     });
   });
+
+  describe('calculateMinimumMoves', () => {
+    test('calculates the correct minimum moves for a given number of disks', () => {
+      expect(game.calculateMinimumMoves()).toBe(7); // 2^3 - 1 = 7
+
+      game = new GameLogic(4); // Initialize a new game with 4 disks
+      expect(game.calculateMinimumMoves()).toBe(15); // 2^4 - 1 = 15
+
+      game = new GameLogic(5); // Initialize a new game with 5 disks
+      expect(game.calculateMinimumMoves()).toBe(31); // 2^5 - 1 = 31
+    });
+  });
 });

--- a/src/tests/utils/gameStateUtils.test.js
+++ b/src/tests/utils/gameStateUtils.test.js
@@ -2,6 +2,7 @@ import {
   resetSelection,
   isTopDisk,
   clearMessages,
+  incrementMoveCount,
 } from '@utils/gameStateUtils';
 
 describe('gameStateUtils', () => {
@@ -48,6 +49,20 @@ describe('gameStateUtils', () => {
 
       expect(setInvalidMoveMessage).toHaveBeenCalledWith('');
       expect(setVictoryMessage).toHaveBeenCalledWith('');
+    });
+  });
+
+  describe('incrementMoveCount', () => {
+    it('increments the move count by 1', () => {
+      const setMoveCount = jest.fn();
+
+      // Call the function
+      incrementMoveCount(setMoveCount);
+
+      // Simulate the updater function passed to setMoveCount
+      const updater = setMoveCount.mock.calls[0][0];
+      expect(updater(0)).toBe(1); // Starts at 0 and increments by 1
+      expect(updater(5)).toBe(6); // Starts at 5 and increments by 1
     });
   });
 });

--- a/src/utils/gameStateUtils.js
+++ b/src/utils/gameStateUtils.js
@@ -12,3 +12,7 @@ export const clearMessages = (setInvalidMoveMessage, setVictoryMessage) => {
   setInvalidMoveMessage('');
   setVictoryMessage('');
 };
+
+export const incrementMoveCount = (setMoveCount) => {
+  setMoveCount((prevCount) => prevCount + 1);
+};

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,3 +1,8 @@
-export { resetSelection, isTopDisk, clearMessages } from './gameStateUtils';
+export {
+  resetSelection,
+  isTopDisk,
+  clearMessages,
+  incrementMoveCount,
+} from './gameStateUtils';
 
 export { getDiskColor } from './diskUtils';

--- a/vite.config.js
+++ b/vite.config.js
@@ -13,6 +13,7 @@ export default defineConfig({
       '@components': path.resolve(__dirname, 'src/components'), // Alias for components
       '@logics': path.resolve(__dirname, 'src/logics'), // Alias for logic
       '@app': path.resolve(__dirname, 'src/App.jsx'), // Alias for the main App component
+      '@constants': path.resolve(__dirname, 'src/constants'), // Alias for constants
     },
   },
 });


### PR DESCRIPTION
This PR introduces the following gameplay features and improvements:

## Turn Counter:

- Tracks the number of turns the player has taken during the game.
- Displays the current move count in the UI.
- Includes a utility function incrementMoveCount with tests to ensure accurate incrementing.

## Reset Game Functionality:

- Adds a "Reset Game" button to restart the game with a custom number of disks.
- Resets all game state, including:
  - Towers
  - Selected disk/tower
  - Victory and invalid move messages
  - Move count

## Testing Enhancements:

- Added tests for all new functionality:
- Turn counter incrementing logic.
- Reset game logic and button behavior.
- Context functionality updates and handling for resetting game state.
- Addressed test coverage for utility functions in gameStateUtils.

## Changelog:
New Features:

- Turn counter with dynamic updating.
- Reset game button with disk count customization.

## Tests:

- 100% coverage for gameStateUtils including incrementMoveCount.
- Added tests for GameContext reset logic and button behavior.
- Mocked and validated useDrag and useDrop behavior for drag-and-drop functionality.

![Screenshot 2025-01-01 at 6 58 02 PM](https://github.com/user-attachments/assets/d0722167-d3d5-43a5-8ef1-af0c55aed6ca)
![Screenshot 2025-01-01 at 6 58 12 PM](https://github.com/user-attachments/assets/698bc8cc-e484-4d72-ad1f-b23aba9c1959)
![Screenshot 2025-01-01 at 6 59 51 PM](https://github.com/user-attachments/assets/9379fddf-cc2e-4cad-8b39-e86d608961c2)
